### PR TITLE
IE doesn't support Element#remove

### DIFF
--- a/app/scripts/lib/bounce/index.coffee
+++ b/app/scripts/lib/bounce/index.coffee
@@ -82,6 +82,11 @@ class Bounce
     deferred
 
   remove: ->
+    do ->
+      w = window
+      w.Element::remove ?= () ->
+        @?.parentNode?.removeChild(@);
+
     @styleElement?.remove()
 
   getPrefixes: (force) ->


### PR DESCRIPTION
We noticed IE was throwing when we passed the `remove: true` option or called `instance.remove()` no IE yet supports the DOM4 remove method so I added some code to check if it exists and polyfill if not. I also attached it to the window as in our case we load our script in an iframe and need to override the window object that bounce uses internally. 